### PR TITLE
Show spinner icon while waiting for signing in

### DIFF
--- a/frontend/src/components/PageContainer.vue
+++ b/frontend/src/components/PageContainer.vue
@@ -3,6 +3,7 @@ import { useRouter } from "vue-router";
 import { store } from "../store";
 import CogIcon from "./CogIcon.vue";
 import { translate } from "../locales/translate";
+import SpinnerIcon from "./SpinnerIcon.vue";
 
 const router = useRouter();
 </script>
@@ -16,19 +17,14 @@ const router = useRouter();
       >
         <div>Top Carcassonner</div>
       </div>
-      <div
-        v-if="!store.authenticated"
-        class="flex flex-col justify-center text-lg"
-        @click="router.push('/signin')"
-      >
-        <div>{{ translate("sign_in") }}</div>
-      </div>
-      <div
-        v-else
-        class="flex flex-col justify-center"
-        @click="router.push('/settings')"
-      >
-        <CogIcon />
+      <div class="flex flex-col justify-center text-lg">
+        <div v-if="store.authenticating"><SpinnerIcon /></div>
+        <div v-else-if="!store.authenticated" @click="router.push('/signin')">
+          {{ translate("sign_in") }}
+        </div>
+        <div v-else @click="router.push('/settings')">
+          <CogIcon />
+        </div>
       </div>
     </div>
     <div class="pb-24">

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -57,7 +57,9 @@ router.beforeEach(async (to) => {
   if (lang) {
     store.setLanguage(lang);
   }
+  store.setAuthenticating(true);
   const currentUser = (await getCurrentUser()) as any;
+  store.setAuthenticating(false);
   if (to.path !== "/signin" && to.path !== "/signup") {
     if (currentUser) {
       store.setAuthenticated(true);

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -6,6 +6,11 @@ export const store = reactive({
     this.userID = userID;
   },
 
+  authenticating: false,
+  setAuthenticating(authenticating: boolean) {
+    this.authenticating = authenticating;
+  },
+
   authenticated: false,
   setAuthenticated(authenticated: boolean) {
     this.authenticated = authenticated;


### PR DESCRIPTION
When the page is re-opened later or reloaded, the "Sign In" button at the top should not appear while checking if the user is authenticated or not (because otherwise users would click that button and try to sign in again, immediately after they see the button "Sign In", even when they don't need to).