### PR TITLE
Fix board position on top when scrolled on problem page

### DIFF
--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
+import { ref, onMounted, computed } from "vue";
 import { Tile } from "../tiles";
 import Panzoom from "@panzoom/panzoom";
 import TileSquare from "./TileSquare.vue";
 import { TilePosition } from "../types";
+import WoodImg from "../assets/img/background-wood.png";
 
 defineProps<{
   placeablePositions: TilePosition[];
@@ -11,6 +12,7 @@ defineProps<{
   placingTile: Tile | null;
   placingPosition: TilePosition | null;
   meepleablePositions: number[];
+  isLarge: boolean;
 }>();
 const emit = defineEmits<{
   (e: "tilePositionSelected", pos: TilePosition): void;
@@ -35,47 +37,59 @@ onMounted(() => {
     }
   }
 });
+
+const boardStyle = computed(() => {
+  return {
+    "background-image": "url(" + WoodImg + ")",
+  };
+});
 </script>
 
 <template>
-  <div ref="elem">
-    <div class="row" v-for="(row, y) in tiles" :key="y">
-      <div v-for="(tile, x) in row" :key="x">
-        <TileSquare
-          v-if="
-            tile !== null &&
-            meepleablePositions.length > 0 &&
-            placingPosition !== null &&
-            placingPosition.y === y &&
-            placingPosition.x === x
-          "
-          :state="'meepling'"
-          :tile="tile"
-          :meepleablePositions="meepleablePositions"
-          @placeMeeple="handlePlaceMeeple"
-        />
-        <TileSquare v-else-if="tile !== null" :state="'normal'" :tile="tile" />
-        <TileSquare
-          v-else-if="
-            placingPosition !== null &&
-            placingPosition.y === y &&
-            placingPosition.x === x
-          "
-          :state="'placing'"
-          :tile="placingTile"
-          :onClick="() => $emit('turnTile')"
-        />
-        <TileSquare
-          v-else-if="
-            placeablePositions.filter((pos) => {
-              return pos.y === y && pos.x === x;
-            }).length > 0
-          "
-          :tile="null"
-          :state="'shadow'"
-          :onClick="() => $emit('tilePositionSelected', { y, x })"
-        />
-        <TileSquare v-else :state="'empty'" :tile="null" />
+  <div :class="isLarge ? 'board-large' : 'board-small'" :style="boardStyle">
+    <div ref="elem">
+      <div class="row" v-for="(row, y) in tiles" :key="y">
+        <div v-for="(tile, x) in row" :key="x">
+          <TileSquare
+            v-if="
+              tile !== null &&
+              meepleablePositions.length > 0 &&
+              placingPosition !== null &&
+              placingPosition.y === y &&
+              placingPosition.x === x
+            "
+            :state="'meepling'"
+            :tile="tile"
+            :meepleablePositions="meepleablePositions"
+            @placeMeeple="handlePlaceMeeple"
+          />
+          <TileSquare
+            v-else-if="tile !== null"
+            :state="'normal'"
+            :tile="tile"
+          />
+          <TileSquare
+            v-else-if="
+              placingPosition !== null &&
+              placingPosition.y === y &&
+              placingPosition.x === x
+            "
+            :state="'placing'"
+            :tile="placingTile"
+            :onClick="() => $emit('turnTile')"
+          />
+          <TileSquare
+            v-else-if="
+              placeablePositions.filter((pos) => {
+                return pos.y === y && pos.x === x;
+              }).length > 0
+            "
+            :tile="null"
+            :state="'shadow'"
+            :onClick="() => $emit('tilePositionSelected', { y, x })"
+          />
+          <TileSquare v-else :state="'empty'" :tile="null" />
+        </div>
       </div>
     </div>
   </div>
@@ -84,5 +98,13 @@ onMounted(() => {
 <style scoped>
 .row {
   display: flex;
+}
+.board-small {
+  border-radius: 0.5%;
+  height: 400px;
+}
+.board-large {
+  border-radius: 0.5%;
+  height: calc(100vh - 215px);
 }
 </style>

--- a/frontend/src/components/VoteItem.vue
+++ b/frontend/src/components/VoteItem.vue
@@ -24,7 +24,10 @@ defineProps<{
           {{ vote.playerName }}
         </div>
       </div>
-      <div v-if="isOpen" class="pl-2 pt-2 text-xs break-words">
+      <div
+        v-if="isOpen && vote.note !== ''"
+        class="pl-2 pt-2 text-xs break-words"
+      >
         {{ vote.note }}
       </div>
     </div>

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -6,7 +6,6 @@ import GameBoard from "../components/GameBoard.vue";
 import PlayerInfo from "../components/PlayerInfo.vue";
 import { translate } from "../locales/translate";
 import { store } from "../store";
-import WoodImg from "../assets/img/background-wood.png";
 import SpinnerIcon from "../components/SpinnerIcon.vue";
 import {
   boardSize,
@@ -671,12 +670,6 @@ const skip = async () => {
   await handlePlaceMeeple(-1);
 };
 
-const boardStyle = computed(() => {
-  return {
-    "background-image": "url(" + WoodImg + ")",
-  };
-});
-
 const placingTileSrc = computed(() => {
   return placingTile.value?.src;
 });
@@ -836,7 +829,7 @@ onMounted(async () => {
         :profileImageURL="player1ProfileImageURL"
       />
     </div>
-    <div class="board mt-3" :style="boardStyle">
+    <div class="mt-3">
       <GameBoard
         :tiles="tiles"
         :placeablePositions="placeablePositions"
@@ -846,6 +839,7 @@ onMounted(async () => {
         @tilePositionSelected="handleTilePositionSelected"
         @turnTile="handleTurnTile"
         @placeMeeple="handlePlaceMeeple"
+        :isLarge="true"
       />
     </div>
     <div class="absolute bottom-36 w-full flex justify-between px-8">
@@ -868,9 +862,3 @@ onMounted(async () => {
     </div>
   </div>
 </template>
-<style scoped>
-.board {
-  border-radius: 0.5%;
-  height: calc(100vh - 215px);
-}
-</style>

--- a/frontend/src/views/ProblemView.vue
+++ b/frontend/src/views/ProblemView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, computed } from "vue";
+import { onMounted, ref } from "vue";
 import {
   Problem,
   Player,
@@ -27,7 +27,6 @@ import {
   TileKind,
   getRemainingTileKinds,
 } from "../tiles";
-import WoodImg from "../assets/img/background-wood.png";
 import { translate } from "../locales/translate";
 
 const problem = ref<Problem | null>(null);
@@ -54,6 +53,7 @@ const meeplingPosition = ref<number>(-1);
 const note = ref<string>("");
 const showRemainingTiles = ref<boolean>(false);
 const remainingTilesSrc = ref<string[]>([]);
+const fixBoard = ref<boolean>(false);
 
 const voted = ref<boolean>(false);
 const votes = ref<Vote[]>([]);
@@ -145,12 +145,6 @@ const handleTurnTile = () => {
     placingTile.value?.rotate();
   }
 };
-
-const boardStyle = computed(() => {
-  return {
-    "background-image": "url(" + WoodImg + ")",
-  };
-});
 
 const currentTile = () => {
   if (!game.value) {
@@ -344,6 +338,14 @@ onMounted(async () => {
     voted.value = true;
     updateVotes();
   }
+
+  document.addEventListener("scroll", () => {
+    if (window.scrollY >= 203) {
+      fixBoard.value = true;
+    } else {
+      fixBoard.value = false;
+    }
+  });
 });
 
 const updateVotes = async () => {
@@ -425,17 +427,23 @@ const updateBoard = async (vote: Vote | null) => {
       :profileImageURL="''"
     />
   </div>
-  <div class="board mt-3" :style="boardStyle">
-    <GameBoard
-      :tiles="tiles"
-      :placeablePositions="placeablePositions"
-      :placingTile="placingTile"
-      :placingPosition="placingPosition"
-      :meepleablePositions="meepleablePositions"
-      @tilePositionSelected="handleTilePositionSelected"
-      @turnTile="handleTurnTile"
-      @placeMeeple="handlePlaceMeeple"
-    />
+  <div class="mt-3">
+    <div :class="fixBoard ? 'fixed top-0 w-full' : ''">
+      <GameBoard
+        :tiles="tiles"
+        :placeablePositions="placeablePositions"
+        :placingTile="placingTile"
+        :placingPosition="placingPosition"
+        :meepleablePositions="meepleablePositions"
+        @tilePositionSelected="handleTilePositionSelected"
+        @turnTile="handleTurnTile"
+        @placeMeeple="handlePlaceMeeple"
+        :isLarge="false"
+      />
+    </div>
+    <div v-if="fixBoard" class="h-[400px]">
+      <!-- keeps height for fixing a board -->
+    </div>
   </div>
   <div class="bg-gray-100 rounded text-gray-900 text-sm px-4 py-3 shadow-md">
     <div class="flex">
@@ -526,9 +534,3 @@ const updateBoard = async (vote: Vote | null) => {
     </div>
   </div>
 </template>
-<style>
-.board {
-  border-radius: 0.5%;
-  height: 400px;
-}
-</style>

--- a/frontend/src/views/ReplayView.vue
+++ b/frontend/src/views/ReplayView.vue
@@ -4,7 +4,6 @@ import { useRoute } from "vue-router";
 import { API } from "../api";
 import { boardSize, getInitialBoard, newTile, Tile, TileKind } from "../tiles";
 import { Board, DiscardMove, Game, TileMove } from "../types";
-import WoodImg from "../assets/img/background-wood.png";
 import { translate } from "../locales/translate";
 import GameBoard from "../components/GameBoard.vue";
 import PlayerInfo from "../components/PlayerInfo.vue";
@@ -131,12 +130,6 @@ const update = async () => {
   }
 };
 
-const boardStyle = computed(() => {
-  return {
-    "background-image": "url(" + WoodImg + ")",
-  };
-});
-
 const winner = computed(() => {
   if (!game.value) {
     return "";
@@ -250,13 +243,14 @@ onMounted(async () => {
       :tileSrc="null"
     />
   </div>
-  <div class="board mt-3" :style="boardStyle">
+  <div class="board mt-3">
     <GameBoard
       :tiles="tiles"
       :placeablePositions="[]"
       :placingTile="null"
       :placingPosition="null"
       :meepleablePositions="[]"
+      :isLarge="true"
     />
   </div>
 </template>


### PR DESCRIPTION
When we view vote results, we also want to see the move of the votes, which is hidden when there are many votes. We fix this problem by fixing the position of the board on the top of the page when the page is scrolled.