### PR TITLE
Add vote count on problems and fetch problems without moves

### DIFF
--- a/backend/migrations/2023-10-20-061830_add-vote-count-to-problem/down.sql
+++ b/backend/migrations/2023-10-20-061830_add-vote-count-to-problem/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE problem DROP COLUMN vote_count;

--- a/backend/migrations/2023-10-20-061830_add-vote-count-to-problem/up.sql
+++ b/backend/migrations/2023-10-20-061830_add-vote-count-to-problem/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE problem ADD COLUMN vote_count INT NOT NULL DEFAULT 0;

--- a/backend/src/player.rs
+++ b/backend/src/player.rs
@@ -95,7 +95,7 @@ pub async fn upload_profile_image(
             profile_image_url.clone(),
         );
 
-        let votes = database::get_votes(None, Some(player_id))?;
+        let votes = database::get_votes(None, Some(player_id), false)?;
         for vote in &votes {
             database::update_vote(vote.id, profile_image_url.clone())?;
         }
@@ -129,7 +129,7 @@ async fn update_profile_image_test() {
                 profile_image_url.clone(),
             );
 
-            let votes = database::get_votes(None, Some(player.id)).unwrap();
+            let votes = database::get_votes(None, Some(player.id), false).unwrap();
             for vote in &votes {
                 database::update_vote(vote.id, profile_image_url.clone()).unwrap();
             }

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -91,6 +91,7 @@ diesel::table! {
         start_at -> Nullable<Timestamp>,
         creator_id -> Nullable<Int4>,
         creator_name -> Nullable<Varchar>,
+        vote_count -> Int4,
     }
 }
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -604,6 +604,7 @@ export class API {
         name: res.data.name,
         creatorID: res.data.creator_id,
         creatorName: res.data.creator_name,
+        voteCount: res.data.vote_count,
       };
       return prob;
     } catch (e) {
@@ -624,6 +625,7 @@ export class API {
           name: p.name,
           creatorID: p.creator_id,
           creatorName: p.creator_name,
+          voteCount: p.vote_count,
         };
       });
       return problems;
@@ -682,30 +684,42 @@ export class API {
     }
   }
 
-  async getVotes(problemID?: number): Promise<Vote[]> {
+  async getVotes(
+    problemID: number | null,
+    playerID: number | null
+  ): Promise<Vote[]> {
     try {
       let url = `${this.base_url}/votes`;
       if (problemID) {
         url = `${url}?problem=${problemID}`;
       }
+      if (playerID) {
+        url = `${url}?player=${playerID}`;
+      }
       const res = await axios.get(url);
       console.log({ res });
       const votes: Vote[] = res.data.map((v: any) => {
-        const tileMove: TileMove = {
-          id: v.tile_move.id,
-          playerID: v.tile_move.player_id,
-          ord: v.tile_move.ord,
-          tile: v.tile_move.tile,
-          pos: { y: v.tile_move.pos[0], x: v.tile_move.pos[1] },
-          rot: v.tile_move.rot,
-        };
-        const meepleMove: MeepleMove = {
-          id: v.meeple_move.id,
-          playerID: v.meeple_move.player_id,
-          ord: v.meeple_move.ord,
-          meepleID: v.meeple_move.meeple_id,
-          pos: v.meeple_move.meeple_pos,
-        };
+        let tileMove: TileMove | null = null;
+        if (v.tile_move) {
+          tileMove = {
+            id: v.tile_move.id,
+            playerID: v.tile_move.player_id,
+            ord: v.tile_move.ord,
+            tile: v.tile_move.tile,
+            pos: { y: v.tile_move.pos[0], x: v.tile_move.pos[1] },
+            rot: v.tile_move.rot,
+          };
+        }
+        let meepleMove: MeepleMove | null = null;
+        if (v.meeple_move) {
+          meepleMove = {
+            id: v.meeple_move.id,
+            playerID: v.meeple_move.player_id,
+            ord: v.meeple_move.ord,
+            meepleID: v.meeple_move.meeple_id,
+            pos: v.meeple_move.meeple_pos,
+          };
+        }
         return {
           id: v.id,
           problemID: v.problem_id,

--- a/frontend/src/components/ProblemItem.vue
+++ b/frontend/src/components/ProblemItem.vue
@@ -6,7 +6,6 @@ import PersonIcon from "../components/PersonIcon.vue";
 defineProps<{
   problem: Problem;
   voted: boolean;
-  voteCount: number;
 }>();
 
 const router = useRouter();
@@ -26,7 +25,7 @@ const router = useRouter();
           <PersonIcon />
         </div>
         <div class="flex flex-col justify-center">
-          {{ voteCount }}
+          {{ problem.voteCount }}
         </div>
       </div>
       <div class="w-5">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -101,6 +101,7 @@ export interface Problem {
   name: string;
   creatorID: number;
   creatorName: string;
+  voteCount: number;
 }
 
 export interface Vote {
@@ -110,6 +111,6 @@ export interface Vote {
   playerName: string;
   playerProfileImageURL: string;
   note: string;
-  tileMove: TileMove;
-  meepleMove: MeepleMove;
+  tileMove: TileMove | null;
+  meepleMove: MeepleMove | null;
 }

--- a/frontend/src/views/ProblemView.vue
+++ b/frontend/src/views/ProblemView.vue
@@ -260,7 +260,7 @@ const createVote = async () => {
   placingPosition.value = null;
 
   voted.value = true;
-  votes.value = await api.getVotes(problem.value.id);
+  votes.value = await api.getVotes(problem.value.id, null);
 };
 
 onMounted(async () => {
@@ -331,7 +331,7 @@ onMounted(async () => {
   );
 
   // if there's already a vote from the player, show results
-  const tmpVotes = await api.getVotes(problem.value.id);
+  const tmpVotes = await api.getVotes(problem.value.id, null);
   const myVotes = tmpVotes.filter((v) => v.playerID === player.value?.id);
   if (myVotes.length > 0) {
     placeablePositions.value = [];
@@ -363,13 +363,13 @@ const handleClickVote = (voteID: number) => {
 };
 
 const updateBoard = async (vote: Vote | null) => {
-  if (prevVote.value) {
+  if (prevVote.value && prevVote.value.tileMove) {
     tiles.value[prevVote.value.tileMove.pos.y + Math.floor(boardSize / 2)][
       prevVote.value.tileMove.pos.x + Math.floor(boardSize / 2)
     ] = null;
   }
 
-  if (vote) {
+  if (vote && vote.tileMove && vote.meepleMove) {
     const tileMove = vote.tileMove;
     const meepleMove = vote.meepleMove;
     const tile = newTile(

--- a/frontend/src/views/ProblemsView.vue
+++ b/frontend/src/views/ProblemsView.vue
@@ -9,7 +9,6 @@ import SpinnerIcon from "../components/SpinnerIcon.vue";
 
 const problems = ref<Problem[]>([]);
 const voted = ref<boolean[]>([]);
-const voteCounts = ref<number[]>([]);
 const player = ref<Player | null>(null);
 const loading = ref<boolean>(false);
 
@@ -20,14 +19,9 @@ onMounted(async () => {
   player.value = await api.getPlayerByUserID(store.userID);
   problems.value = await api.getProblems();
 
-  const votes = await api.getVotes();
-  const votedProblemIDs = votes
-    .filter((v) => v.playerID == player.value?.id)
-    .map((v) => v.problemID);
+  const myVotes = await api.getVotes(null, player.value.id);
+  const votedProblemIDs = myVotes.map((v) => v.problemID);
   voted.value = problems.value.map((p) => votedProblemIDs.includes(p.id));
-  voteCounts.value = problems.value.map(
-    (p) => votes.filter((v) => v.problemID === p.id).length
-  );
 
   loading.value = false;
 });
@@ -45,7 +39,6 @@ onMounted(async () => {
         v-for="(problem, idx) in problems"
         :problem="problem"
         :voted="voted[idx]"
-        :voteCount="voteCounts[idx]"
         :key="problem.id"
       />
     </div>


### PR DESCRIPTION
Fetching problems is so slow. This is probably because when fetching problems, we currently fetch votes with tile moves and meeple moves, which is probably slow. So we fix it by:
- filling moves in votes only when needed
- saving vote count on problem tables and update it every time a user creates a vote