### PR TITLE
Change some buttons to hyperlink that can be opened in new tab

### DIFF
--- a/frontend/src/components/DraftProblemItem.vue
+++ b/frontend/src/components/DraftProblemItem.vue
@@ -1,18 +1,15 @@
 <script setup lang="ts">
-import { useRouter } from "vue-router";
 import { Problem } from "../types";
 import { useFormatDate } from "../composables/date";
 
 defineProps<{
   problem: Problem;
 }>();
-
-const router = useRouter();
 </script>
 
 <template>
-  <div
-    @click="router.push(`/problems/${problem.id}/edit`)"
+  <a
+    :href="`/problems/${problem.id}/edit`"
     class="flex justify-between border rounded-md px-2 py-2 mb-2 bg-white hover:bg-gray-50 hover:cursor-pointer text-gray-700"
   >
     <div>{{ problem.name !== "" ? problem.name : "untitled" }}</div>
@@ -20,5 +17,5 @@ const router = useRouter();
       {{ useFormatDate(problem.startAt) }}
     </div>
     <div class="text-sm">{{ problem.creatorName }}</div>
-  </div>
+  </a>
 </template>

--- a/frontend/src/components/ProblemItem.vue
+++ b/frontend/src/components/ProblemItem.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useRouter } from "vue-router";
 import { Problem } from "../types";
 import PersonIcon from "../components/PersonIcon.vue";
 import { computed } from "vue";
@@ -8,8 +7,6 @@ const props = defineProps<{
   problem: Problem;
   voted: boolean;
 }>();
-
-const router = useRouter();
 
 const formatNumber = computed(() => {
   if (!props.problem || !props.problem.num) {
@@ -30,8 +27,8 @@ const formatNumber = computed(() => {
 </script>
 
 <template>
-  <div
-    @click="router.push(`/problems/${problem.id}`)"
+  <a
+    :href="`/problems/${problem.id}`"
     class="flex justify-between border rounded-md px-2 py-2 mb-2 bg-white hover:bg-gray-50 hover:cursor-pointer"
   >
     <div class="flex flex-col justify-center">
@@ -56,5 +53,5 @@ const formatNumber = computed(() => {
         </div>
       </div>
     </div>
-  </div>
+  </a>
 </template>


### PR DESCRIPTION
fix #110 

- Opening more than one problems at once in several tabs is really useful, but it was impossible. Since it seems that something like `<div @click="router.push(...` cannot be opened in new tab.
- Use `<a href="...` instead. Notice that this seems a bit slower than `router.push`, but it's still worth doing.