### PR TITLE
Fix evaluator's calculation

### DIFF
--- a/backend/src/game/calculate_next_move.rs
+++ b/backend/src/game/calculate_next_move.rs
@@ -265,5 +265,32 @@ fn calculate_next_move_invade_test0() {
     */
 }
 
+/*
 #[test]
-fn calculate_next_move_test() {}
+fn calculate_next_move_test() {
+    use diesel::pg::PgConnection;
+    use diesel::r2d2::ConnectionManager;
+    use diesel::r2d2::Pool;
+    use dotenvy::dotenv;
+    use std::env;
+    use std::time::Duration;
+
+    dotenv().ok();
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let manager = ConnectionManager::<PgConnection>::new(database_url);
+    let db = Pool::builder()
+        .max_size(1) // FIXME: Didn't think about this number carefully
+        .connection_timeout(Duration::from_secs(300))
+        .build(manager)
+        .expect("Creating a pool failed");
+
+    let game_id = 19280;
+    let mut mvs = super::database::list_moves(&db, game_id, None).unwrap();
+    mvs = mvs[0..98].to_vec();
+
+    let (tile_move, meeple_move) = calculate_next_move(&mvs, None, 0, 1, 1, Tile::Curve).unwrap();
+
+    println!("tile_move = {:?}", tile_move);
+    println!("meeple_move = {:?}", meeple_move);
+}
+*/

--- a/backend/src/game/debug_moves.rs
+++ b/backend/src/game/debug_moves.rs
@@ -127,7 +127,8 @@ pub fn list_evaluate_results(moves: &Vec<Move>, next_tile: Tile) {
                     };
                     mvs.push(Move::MMove(mmove.clone()));
 
-                    let (res0, res1) = evaluate(&mvs, false);
+                    let debug = false; /* tmove.pos == (-5, 2) && tmove.rot == 2 && mmove.meeple_pos == 1; */
+                    let (res0, res1) = evaluate(&mvs, debug);
 
                     results.push((tmove.clone(), mmove, res0, res1, res1 - res0));
 
@@ -211,16 +212,31 @@ fn compare_evaluate_results(moves: &Vec<Move>, next_tile: Tile, compare_moves: &
 
 /*
 #[test]
-fn test_results() {
-    let game_id = 689;
-    let mut mvs = super::database::list_moves(game_id, None).unwrap();
+fn test_evaluate_results() {
+    use diesel::pg::PgConnection;
+    use diesel::r2d2::ConnectionManager;
+    use diesel::r2d2::Pool;
+    use dotenvy::dotenv;
+    use std::env;
+    use std::time::Duration;
 
-    mvs = mvs[0..2].to_vec();
+    dotenv().ok();
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let manager = ConnectionManager::<PgConnection>::new(database_url);
+    let db = Pool::builder()
+        .max_size(1) // FIXME: Didn't think about this number carefully
+        .connection_timeout(Duration::from_secs(300))
+        .build(manager)
+        .expect("Creating a pool failed");
+
+    let game_id = 11720;
+    let mut mvs = super::database::list_moves(&db, game_id, None).unwrap();
+
+    mvs = mvs[0..18].to_vec();
     println!("mvs = {:?}", mvs);
     println!();
 
-    /*
-    let next_tile = Tile::ConnectorWithCOA;
+    let next_tile = Tile::TriangleWithRoad;
 
     list_evaluate_results(&mvs, next_tile);
 
@@ -241,6 +257,5 @@ fn test_results() {
         ],
     );
     assert!(true);
-    */
 }
 */

--- a/backend/src/game/evaluate.rs
+++ b/backend/src/game/evaluate.rs
@@ -842,9 +842,9 @@ pub fn evaluate(moves: &Vec<Move>, debug: bool) -> (i32, i32) {
                     println!("complete_prob = {:?}", complete_prob);
                 }
                 if feature.player0_meeples > feature.player1_meeples {
-                    result0 = c;
+                    result0 += c;
                 } else if feature.player0_meeples < feature.player1_meeples {
-                    result1 = c;
+                    result1 += c;
                 }
             }
         }


### PR DESCRIPTION
fix #96

- The line that is supposed to be `result += c` was `result = c` (which only evaluated the final `c` value), which is obviously wrong. This bug have caused some irrational moves (like taking 0 point field , taking one point road, etc.).